### PR TITLE
Fix missing axios in docker by preserving node_modules

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     command: ["node", "draw.js"]
     volumes:
       - .:/app
+      - /app/node_modules
     working_dir: /app
     restart: always
 
@@ -15,6 +16,7 @@ services:
     command: ["node", "grow_all.js"]
     volumes:
       - .:/app
+      - /app/node_modules
     working_dir: /app
     restart: always
 
@@ -24,6 +26,7 @@ services:
     command: ["node", "deposit.js"]
     volumes:
       - .:/app
+      - /app/node_modules
     working_dir: /app
     restart: always
 


### PR DESCRIPTION
## Summary
- keep node_modules from the Docker image by adding a dedicated volume

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68426273d89c83218c76c5fe29744332